### PR TITLE
Fix memory leak in async

### DIFF
--- a/src/async.cc
+++ b/src/async.cc
@@ -1,4 +1,6 @@
-#include <unistd.h>
+#include <unistd.h> // access()
+#include <string.h> // strdup()
+#include <stdlib.h> // free()
 #include "async.h"
 
 using namespace Nan;
@@ -16,7 +18,9 @@ private:
 
 public:
     AccessWorker(char *path, int amode, Callback *callback) : AsyncWorker(callback), path(path), amode(amode) {}
-    ~AccessWorker() {}
+    ~AccessWorker() {
+        free(path);
+    }
 
     // Executed inside the worker-thread
     // It is not safe to access V8, or V8 data structures here, so everything we need for input and output should go on `this`


### PR DESCRIPTION
A `path` string allocated by `strdup()` was being leaked on each call to `accessAsync()`.

The [`fix-leak-travis`](https://github.com/motiz88/node-unix-access/tree/fix-leak-travis) branch, which is the same code with some testing-related commits added, [passes all the tests](https://travis-ci.org/motiz88/node-unix-access/builds/93175491).
